### PR TITLE
Set constructor of Singleton class as private

### DIFF
--- a/chapter-3/src/singleton.ts
+++ b/chapter-3/src/singleton.ts
@@ -25,6 +25,8 @@ namespace Singleton {
     
     class Singleton {
         private static _default: Singleton;
+        
+        private constructor(){}
 
         static get default(): Singleton {
             if (Singleton._default) {


### PR DESCRIPTION
For the sake to forbid an instantiation through `new Singleton()`.  
The only way must be with help `Singleton.default`.